### PR TITLE
travis: Add initial Travis continuous integration configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+dist: focal
+sudo: false
+language: cpp
+
+addons:
+  apt:
+    packages: ninja-build libboost-dev libboost-system-dev libboost-thread-dev libboost-chrono-dev
+
+script:
+  - mkdir -p travis-build
+  - cd travis-build
+  - cmake .. -G Ninja
+  - cmake --build .
+  - ctest .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,8 +77,7 @@ add_library(dbus-asio SHARED
 )
 
 # DBUS DEPENDENCIES
-find_package(Boost COMPONENTS system REQUIRED)
-find_package(Boost COMPONENTS thread REQUIRED)
+find_package(Boost COMPONENTS system thread REQUIRED)
 include_directories(${Boost_INCLUDE_DIR})
 set (PRIVATE_LIBS ${Boost_LIBRARIES})
 link_directories(${Boost_LIBRARY_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ add_library(dbus-asio SHARED
 )
 
 # DBUS DEPENDENCIES
-find_package(Boost COMPONENTS system thread REQUIRED)
+find_package(Boost COMPONENTS chrono system thread REQUIRED)
 include_directories(${Boost_INCLUDE_DIR})
 set (PRIVATE_LIBS ${Boost_LIBRARIES})
 link_directories(${Boost_LIBRARY_DIRS})


### PR DESCRIPTION
This series improves dbus-asio performance greatly by removing inefficient checks and not reading a single byte at a time.