### PR TITLE
dbus_native: Drop pointer to Transport before AuthenticationProtocol

### DIFF
--- a/src/dbus_native.cpp
+++ b/src/dbus_native.cpp
@@ -26,9 +26,9 @@ std::string DBus::Native::DBusDaemon("org.freedesktop.DBus");
 
 DBus::Native::Native(const std::string& busname)
     : m_MessageProtocol(new DBus::MessageProtocol())
-    , m_Transport(new DBus::Transport(busname))
-    , m_AuthenticationProtocol(new DBus::AuthenticationProtocol(m_Transport))
 {
+    m_Transport.reset(new DBus::Transport(busname));
+    m_AuthenticationProtocol.reset(new DBus::AuthenticationProtocol(m_Transport));
     m_Transport->setDataHandler(
         std::bind(&Native::onReceiveAuthData, this, std::placeholders::_1));
     m_MessageProtocol->setMethodCallHandler(

--- a/src/dbus_native.h
+++ b/src/dbus_native.h
@@ -158,8 +158,8 @@ private:
     std::map<std::string, MatchRule> m_RulesMap;
 
     std::unique_ptr<MessageProtocol> m_MessageProtocol;
-    std::shared_ptr<Transport> m_Transport;
     std::unique_ptr<AuthenticationProtocol> m_AuthenticationProtocol;
+    std::shared_ptr<Transport> m_Transport;
 
 public:
     static std::string DBusDaemon;


### PR DESCRIPTION
We hold a shared_ptr to Transport and so does AuthenticationProtocol.
By dropping ours first, we ensure that Transport is gone by the time
~AuthenticationProtocol() returns, and there is no risk of Transport
attempting to dispatch any calls to the dead AuthenticationProtocol
object.

This leads to the slightly unusual situation where we want
AuthenticationProtocol to be both constructed and destructed
before Transport, rather than the usual last-in-first-out
model that C++ would give us automatically.  So we must do
the construction explicitly to get the ordering we need.

Change-Id: Ifb8fdfa2bd6e5270d4ad8bdba111095c2e87e02d