### PR TITLE
add support for broadcasting DBus signals

### DIFF
--- a/src/dbus_message_signal.cpp
+++ b/src/dbus_message_signal.cpp
@@ -71,12 +71,13 @@ DBus::Message::Signal::marshall(const std::string& destination) const
     sPath.add(DBus::Type::Variant(DBus::Type::ObjectPath(m_SignalName.m_Object)));
     array.add(sPath);
 
-    // This is necessary, to prevent errors from the daemon,although it is marked
-    // as optional in the spec
-    DBus::Type::Struct sDestination;
-    sDestination.add(DBus::Type::Byte(DBus::Message::Header::HEADER_DESTINATION));
-    sDestination.add(DBus::Type::Variant(DBus::Type::String(destination)));
-    array.add(sDestination);
+    if (destination.size()) {
+      // Unicast signal to a single destination
+      DBus::Type::Struct sDestination;
+      sDestination.add(DBus::Type::Byte(DBus::Message::Header::HEADER_DESTINATION));
+      sDestination.add(DBus::Type::Variant(DBus::Type::String(destination)));
+      array.add(sDestination);
+    }
 
     DBus::Type::Struct sInterface;
     sInterface.add(DBus::Type::Byte(DBus::Message::Header::HEADER_INTERFACE));

--- a/src/dbus_native.cpp
+++ b/src/dbus_native.cpp
@@ -151,6 +151,12 @@ void DBus::Native::sendSignal(const std::string& destination,
     m_Transport->sendString(signal.marshall(destination));
 }
 
+void DBus::Native::broadcastSignal(const DBus::Message::Signal& signal)
+{
+    ++m_Stats.count_sent_signals;
+    m_Transport->sendString(signal.marshall(""));
+}
+
 //
 // Handle incoming messages
 //

--- a/src/dbus_native.h
+++ b/src/dbus_native.h
@@ -56,6 +56,7 @@ public:
         const DBus::Message::Error& err);
     void sendSignal(const std::string& destination,
         const DBus::Message::Signal& signal);
+    void broadcastSignal(const DBus::Message::Signal& signal);
 
     void onReceiveMethodCall(const DBus::Message::MethodCall& method);
     void onReceiveMethodReturn(const Message::MethodReturn& reply);


### PR DESCRIPTION
A broadcast signal has no destination header, which is now possible to
send with the newly added DBus::Native::broadcastSignal() method.

Fixes #14

Signed-off-by: Heiko Hund <heiko@openvpn.net>